### PR TITLE
Add elapsed timer and fixed dispose() hook unsubscribe

### DIFF
--- a/Discord/Discord.cs
+++ b/Discord/Discord.cs
@@ -6,11 +6,13 @@ using DiscordRPC.Message;
 using DiscordRPC.Unity;
 using UnityEngine;
 using R2API;
+using System;
+
 namespace DiscordRichPresence
 {
 	[BepInDependency("com.bepis.r2api")]
 
-	[BepInPlugin("com.whelanb.discord", "Discord Rich Presence", "2.0.0")]
+	[BepInPlugin("com.whelanb.discord", "Discord Rich Presence", "2.1.0")]
 
 	public class Discord : BaseUnityPlugin
 	{
@@ -25,6 +27,7 @@ namespace DiscordRichPresence
 		DiscordRpcClient client;
 
 		static PrivacyLevel currentPrivacyLevel;
+		static DateTime elapsedTime;
 
 		public void Awake()
 		{
@@ -70,6 +73,14 @@ namespace DiscordRichPresence
 				orig(self);
 			};
 
+			Run.onRunStartGlobal += Run_onRunStartGlobal;
+
+		}
+
+		private void Run_onRunStartGlobal(Run obj)
+		{
+			//RoR2 freezes timer during intermissions, but for now just show total elapsed time of run
+			elapsedTime = DateTime.Now;
 		}
 
 		//Remove any lingering hooks and dispose of discord client connection
@@ -232,6 +243,10 @@ namespace DiscordRichPresence
 					},
 					State = "Classic Run",
 					Details = string.Format("Stage {0} - {1}", (self.stageClearCount + 1), RoR2.Language.GetString(scene.nameToken)),
+					Timestamps = new Timestamps()
+					{
+						Start = elapsedTime
+					}
 				};
 				client.SetPresence(presence);
 			}

--- a/Discord/Discord.cs
+++ b/Discord/Discord.cs
@@ -12,11 +12,10 @@ namespace DiscordRichPresence
 {
 	[BepInDependency("com.bepis.r2api")]
 
-	[BepInPlugin("com.whelanb.discord", "Discord Rich Presence", "2.1.0")]
+	[BepInPlugin("com.whelanb.discord", "Discord Rich Presence", "2.1.1")]
 
 	public class Discord : BaseUnityPlugin
 	{
-
 		enum PrivacyLevel
 		{
 			Disabled = 0,
@@ -26,8 +25,8 @@ namespace DiscordRichPresence
 
 		DiscordRpcClient client;
 
-		static PrivacyLevel currentPrivacyLevel;
-		static DateTime elapsedTime;
+		static PrivacyLevel currentPrivacyLevel;	
+		static DateTimeOffset runStartTime;
 
 		public void Awake()
 		{
@@ -72,21 +71,12 @@ namespace DiscordRichPresence
 				CommandHelper.RegisterCommands(self);
 				orig(self);
 			};
-
-			Run.onRunStartGlobal += Run_onRunStartGlobal;
-
-		}
-
-		private void Run_onRunStartGlobal(Run obj)
-		{
-			//RoR2 freezes timer during intermissions, but for now just show total elapsed time of run
-			elapsedTime = DateTime.Now;
 		}
 
 		//Remove any lingering hooks and dispose of discord client connection
 		public void Dispose()
 		{
-			On.RoR2.Run.BeginStage += Run_BeginStage;
+			On.RoR2.Run.BeginStage -= Run_BeginStage;
 
 			On.RoR2.SteamworksLobbyManager.OnLobbyCreated -= SteamworksLobbyManager_OnLobbyCreated;
 			On.RoR2.SteamworksLobbyManager.OnLobbyJoined -= SteamworksLobbyManager_OnLobbyJoined;
@@ -146,6 +136,7 @@ namespace DiscordRichPresence
 		private void Client_OnJoinRequested(object sender, JoinRequestMessage args)
 		{
 			Logger.LogInfo(string.Format("User {0} asked to join lobby", args.User.Username));
+			Chat.AddMessage(string.Format("Discord user {0} has asked to join your game!", args.User.Username));
 			//Always let people into your game for now
 			client.Respond(args, true);
 		}
@@ -162,16 +153,15 @@ namespace DiscordRichPresence
 			Logger.LogInfo("Discord Rich Presence Ready - User: " + args.User.Username);
 		}
 
+		//Currently, presence isn't cleared on run/lobby exit - TODO
 		private void SteamworksLobbyManager_LeaveLobby(On.RoR2.SteamworksLobbyManager.orig_LeaveLobby orig)
 		{
-
 			//if (Facepunch.Steamworks.Client.Instance == null)
 			//	return;
 			//Clear for now
 			//if (client != null && client.CurrentPresence != null)
 			//client.ClearPresence();
 			orig();
-
 		}
 
 		//TODO - Refactor these as they all update the Presence with the same data
@@ -229,6 +219,10 @@ namespace DiscordRichPresence
 		//When the game begins a new stage, update presence
 		private void Run_BeginStage(On.RoR2.Run.orig_BeginStage orig, Run self)
 		{
+			//Grab the run start time (elapsed time does not take into account timer freeze from intermissions yet)
+			//Also runs a little fast - find a better hook point!
+			if (self.stageClearCount == 0)
+				runStartTime = DateTimeOffset.Now;
 			if (currentPrivacyLevel != PrivacyLevel.Disabled)
 			{
 				SceneDef scene = SceneCatalog.GetSceneDefForCurrentScene();
@@ -241,12 +235,12 @@ namespace DiscordRichPresence
 						LargeImageText = RoR2.Language.GetString(scene.subtitleToken)
 						//add player character here!
 					},
-					State = "Classic Run",
-					Details = string.Format("Stage {0} - {1}", (self.stageClearCount + 1), RoR2.Language.GetString(scene.nameToken)),
 					Timestamps = new Timestamps()
 					{
-						Start = elapsedTime
-					}
+						StartUnixMilliseconds = (ulong)runStartTime.ToUnixTimeMilliseconds()
+					},
+					State = "Classic Run",
+					Details = string.Format("Stage {0} - {1}", (self.stageClearCount + 1), RoR2.Language.GetString(scene.nameToken))
 				};
 				client.SetPresence(presence);
 			}
@@ -268,7 +262,7 @@ namespace DiscordRichPresence
 			if(parse)
 				currentPrivacyLevel = (PrivacyLevel)level; //unchecked
 			else
-				Debug.LogError("Failed to parse arg - must be integer value 0-2");
+				Debug.LogError("Failed to parse arg - must be integer value");
 			
 			//TODO - if disabled, clear presence
 		}

--- a/Discord/Discord.csproj
+++ b/Discord/Discord.csproj
@@ -32,6 +32,9 @@
     <Reference Include="MonoMod.Utils">
       <HintPath>..\libs\MonoMod.Utils.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>D:\SteamLibrary\steamapps\common\Risk of Rain 2\BepInEx\plugins\Discord\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="pb_Stl">
       <HintPath>..\libs\pb_Stl.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Discord will begin the elapsed timer when the first stage is loaded. It currently seems to run a second or so fast, so ideally a better hook exists.

It also does not take into account timer freezes during intermissions (bazaar and obelisk)

Also fixed an accidental subscribe in Dispose()