### PR TITLE
Synced elapsed time with run timer

### DIFF
--- a/Discord/Discord.csproj
+++ b/Discord/Discord.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\libs\Assembly-CSharp.dll</HintPath>
+      <HintPath>D:\SteamLibrary\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
       <HintPath>..\libs\BepInEx.dll</HintPath>


### PR DESCRIPTION
Elapsed timer in Discord is now synced with run timer to provide correct time to rich presence card. Time is calculated by taking the current run timer in seconds and subtracting from the current Unix time to retrieve a time in the past from which Discord bases the elapsed timer